### PR TITLE
WIP: Change workflow to self-hosted raspberryPI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted 
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Set up a github action runner on the RaspberryPI and change the python test runner to use it

TODO: Install Python venv manually, as github does not have a pre-compiled python version for aarch64